### PR TITLE
Fix addClaimedResources

### DIFF
--- a/youbot_gazebo_control/src/steered_wheel_base_controller.cpp
+++ b/youbot_gazebo_control/src/steered_wheel_base_controller.cpp
@@ -199,11 +199,12 @@ using XmlRpc::XmlRpcValue;
 
 namespace {
 
-void addClaimedResources(hardware_interface::HardwareInterface *const hw_iface, controller_interface::ControllerBase::ClaimedResources& claimed_resources){
+void addClaimedResources(hardware_interface::HardwareInterface *const hw_iface, std::string hw_iface_name, controller_interface::ControllerBase::ClaimedResources& claimed_resources){
     if (hw_iface == NULL) return;
 
-    hardware_interface::InterfaceResources iface_res( "", hw_iface->getClaims());
-    claimed_resources.assign(1, iface_res);
+    hardware_interface::InterfaceResources iface_res(hw_iface_name, hw_iface->getClaims());
+    if (!iface_res.resources.empty())
+      claimed_resources.push_back(iface_res);
     hw_iface->clearClaims();
 }
 
@@ -874,9 +875,9 @@ bool SteeredWheelBaseController::initRequest(RobotHW *const robot_hw,
     }
 
     claimed_resources.clear();
-    addClaimedResources(eff_joint_iface, claimed_resources);
-    addClaimedResources(pos_joint_iface, claimed_resources);
-    addClaimedResources(vel_joint_iface, claimed_resources);
+    addClaimedResources(eff_joint_iface, "hardware_interface::EffortJointInterface",   claimed_resources);
+    addClaimedResources(pos_joint_iface, "hardware_interface::PositionJointInterface", claimed_resources);
+    addClaimedResources(vel_joint_iface, "hardware_interface::VelocityJointInterface", claimed_resources);
 
     state_ = INITIALIZED;
     return true;


### PR DESCRIPTION
Without this commit, the controller didn't properly set the
hardware_interface name, so the claimed resource management didn't work.
Also, it overwrote the values of the previous hw interfaces (effort +
position) with the last one (velocity). Out of luck, no resources were
claimed for the effort and position interfaces though.

Before:
```
$ rosservice call /controller_manager/list_controllers
controller:
  -
    name: "joint_state_controller"
    state: "running"
    type: "joint_state_controller/JointStateController"
    claimed_resources:
      -
        hardware_interface: "hardware_interface::JointStateInterface"
        resources: []
  -
    name: "base_controller"
    state: "running"
    type: "steered_wheel_base_controller/SteeredWheelBaseController"
    claimed_resources:
      -
        hardware_interface: ''
        resources: [caster_joint_bl, caster_joint_br, caster_joint_fl, caster_joint_fr, wheel_joint_bl,
  wheel_joint_br, wheel_joint_fl, wheel_joint_fr]
  -
    name: "arm_1/gripper_controller"
    state: "running"
    type: "effort_controllers/JointTrajectoryController"
    claimed_resources:
      -
        hardware_interface: "hardware_interface::EffortJointInterface"
        resources: [gripper_finger_joint_l, gripper_finger_joint_r]
  -
    name: "arm_1/arm_controller"
    state: "running"
    type: "effort_controllers/JointTrajectoryController"
    claimed_resources:
      -
        hardware_interface: "hardware_interface::EffortJointInterface"
        resources: [arm_joint_1, arm_joint_2, arm_joint_3, arm_joint_4, arm_joint_5]
```

After:

```
$ rosservice call /controller_manager/list_controllers
controller:
  [...]
  -
    name: "base_controller"
    state: "running"
    type: "steered_wheel_base_controller/SteeredWheelBaseController"
    claimed_resources:
      -
        hardware_interface: "hardware_interface::VelocityJointInterface"
        resources: [caster_joint_bl, caster_joint_br, caster_joint_fl, caster_joint_fr, wheel_joint_bl,
  wheel_joint_br, wheel_joint_fl, wheel_joint_fr]
  [...]
```