### PR TITLE
[youbot gazebo control] missing run depend

### DIFF
--- a/youbot_gazebo_control/package.xml
+++ b/youbot_gazebo_control/package.xml
@@ -33,6 +33,7 @@
   <run_depend>controller_interface</run_depend>
   <run_depend>controller_manager</run_depend>
   <run_depend>hardware_interface</run_depend>
+  <run_depend>joint_trajectory_controller</run_depend>
 
   <test_depend>roslaunch</test_depend>
   

--- a/youbot_gazebo_control/package.xml
+++ b/youbot_gazebo_control/package.xml
@@ -33,6 +33,7 @@
   <run_depend>controller_interface</run_depend>
   <run_depend>controller_manager</run_depend>
   <run_depend>hardware_interface</run_depend>
+  <run_depend>joint_state_controller</run_depend>
   <run_depend>joint_trajectory_controller</run_depend>
 
   <test_depend>roslaunch</test_depend>


### PR DESCRIPTION
The arm controller is type:

    effort_controllers/JointTrajectoryController

I don't think the b-it-bots have come across this issue because usually, someone has also installed `cob_hardware_config` or `cob_bringup` or some other package which would bring in these dependencies.

I came across this on melodic, but it should have been there in kinetic too.