### PR TITLE
Joint velocity control

### DIFF
--- a/youbot_gazebo_control/CMakeLists.txt
+++ b/youbot_gazebo_control/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(catkin REQUIRED
     control_toolbox
     controller_interface
     geometry_msgs
+    brics_actuator
     hardware_interface
     kdl_parser
     nav_msgs
@@ -36,6 +37,13 @@ add_library(steered_wheel_base_controller
 )
 target_link_libraries(steered_wheel_base_controller
   ${catkin_LIBRARIES}
+)
+
+add_executable(arm_joint_vel_convertor
+    src/arm_joint_vel_convertor.cpp
+)
+target_link_libraries(arm_joint_vel_convertor
+    ${catkin_LIBRARIES}
 )
 
 ### TESTS

--- a/youbot_gazebo_control/config/arm_1_vel_controller.yaml
+++ b/youbot_gazebo_control/config/arm_1_vel_controller.yaml
@@ -1,24 +1,24 @@
 joint_1_velocity:
     type: "effort_controllers/JointVelocityController"
     joint: arm_joint_1
-    pid: {p: 30.0, i: 0.0, d: 0.0}
+    pid: {p: 2.0, i: 100.0, d: 0.0, i_clamp_min: -100.0, i_clamp_max: 100.0, antiwindup: true}
 
 joint_2_velocity:
     type: "effort_controllers/JointVelocityController"
     joint: arm_joint_2
-    pid: {p: 30.0, i: 0.0, d: 0.0}
+    pid: {p: 1.0, i: 100.0, d: 0.0, i_clamp_min: -100.0, i_clamp_max: 100.0, antiwindup: true}
 
 joint_3_velocity:
     type: "effort_controllers/JointVelocityController"
     joint: arm_joint_3
-    pid: {p: 30.0, i: 0.0, d: 0.0}
+    pid: {p: 1.0, i: 100.0, d: 0.0, i_clamp_min: -1000.0, i_clamp_max: 1000.0, antiwindup: true}
 
 joint_4_velocity:
     type: "effort_controllers/JointVelocityController"
     joint: arm_joint_4
-    pid: {p: 30.0, i: 0.0, d: 0.0}
+    pid: {p: 1.0, i: 100.0, d: 0.0, i_clamp_min: -1000.0, i_clamp_max: 1000.0, antiwindup: true}
 
 joint_5_velocity:
     type: "effort_controllers/JointVelocityController"
     joint: arm_joint_5
-    pid: {p: 30.0, i: 0.0, d: 0.0}
+    pid: {p: 5.0, i: 100.0, d: 0.0, i_clamp_min: -100.0, i_clamp_max: 100.0, antiwindup: true}

--- a/youbot_gazebo_control/config/arm_1_vel_controller.yaml
+++ b/youbot_gazebo_control/config/arm_1_vel_controller.yaml
@@ -1,0 +1,24 @@
+joint_1_velocity:
+    type: "effort_controllers/JointVelocityController"
+    joint: arm_joint_1
+    pid: {p: 30.0, i: 0.0, d: 0.0}
+
+joint_2_velocity:
+    type: "effort_controllers/JointVelocityController"
+    joint: arm_joint_2
+    pid: {p: 30.0, i: 0.0, d: 0.0}
+
+joint_3_velocity:
+    type: "effort_controllers/JointVelocityController"
+    joint: arm_joint_3
+    pid: {p: 30.0, i: 0.0, d: 0.0}
+
+joint_4_velocity:
+    type: "effort_controllers/JointVelocityController"
+    joint: arm_joint_4
+    pid: {p: 30.0, i: 0.0, d: 0.0}
+
+joint_5_velocity:
+    type: "effort_controllers/JointVelocityController"
+    joint: arm_joint_5
+    pid: {p: 30.0, i: 0.0, d: 0.0}

--- a/youbot_gazebo_control/launch/vel_arm_controller.launch
+++ b/youbot_gazebo_control/launch/vel_arm_controller.launch
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+
+  <arg name="arm_name" default="arm_1"/>
+
+  <!-- upload arm and gripper controller parameters -->
+  <rosparam file="$(find youbot_gazebo_control)/config/$(arg arm_name)_vel_controller.yaml"
+            command="load" ns="$(arg arm_name)"/> 
+ 
+  <!-- spawn vel arm controller -->
+  <node pkg="controller_manager" type="spawner" name="$(arg arm_name)_joint_controller_spawner"
+        args="$(arg arm_name)/joint_1_velocity
+              $(arg arm_name)/joint_2_velocity
+              $(arg arm_name)/joint_3_velocity
+              $(arg arm_name)/joint_4_velocity
+              $(arg arm_name)/joint_5_velocity"
+        respawn="false" output="screen" />
+
+</launch>

--- a/youbot_gazebo_control/launch/vel_arm_controller.launch
+++ b/youbot_gazebo_control/launch/vel_arm_controller.launch
@@ -1,19 +1,22 @@
 <?xml version="1.0"?>
 <launch>
 
-  <arg name="arm_name" default="arm_1"/>
+    <arg name="arm_name" default="arm_1"/>
 
-  <!-- upload arm and gripper controller parameters -->
-  <rosparam file="$(find youbot_gazebo_control)/config/$(arg arm_name)_vel_controller.yaml"
-            command="load" ns="$(arg arm_name)"/> 
- 
-  <!-- spawn vel arm controller -->
-  <node pkg="controller_manager" type="spawner" name="$(arg arm_name)_joint_controller_spawner"
-        args="$(arg arm_name)/joint_1_velocity
-              $(arg arm_name)/joint_2_velocity
-              $(arg arm_name)/joint_3_velocity
-              $(arg arm_name)/joint_4_velocity
-              $(arg arm_name)/joint_5_velocity"
-        respawn="false" output="screen" />
+    <!-- upload arm and gripper controller parameters -->
+    <rosparam file="$(find youbot_gazebo_control)/config/$(arg arm_name)_vel_controller.yaml"
+        command="load" ns="$(arg arm_name)"/> 
+
+    <!-- spawn vel arm controller -->
+    <node pkg="controller_manager" type="spawner" name="$(arg arm_name)_joint_controller_spawner"
+          args="$(arg arm_name)/joint_1_velocity
+                $(arg arm_name)/joint_2_velocity
+                $(arg arm_name)/joint_3_velocity
+                $(arg arm_name)/joint_4_velocity
+                $(arg arm_name)/joint_5_velocity"
+          respawn="false" output="screen" />
+
+    <node pkg="youbot_gazebo_control" type="arm_joint_vel_convertor"
+          name="$(arg arm_name)_joint_joint_vel_convertor"/>
 
 </launch>

--- a/youbot_gazebo_control/package.xml
+++ b/youbot_gazebo_control/package.xml
@@ -19,6 +19,7 @@
   <build_depend>control_toolbox</build_depend>
   <build_depend>controller_interface</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>brics_actuator</build_depend>
   <build_depend>hardware_interface</build_depend>
   <build_depend>kdl_parser</build_depend>
   <build_depend>nav_msgs</build_depend>
@@ -35,6 +36,7 @@
   <run_depend>hardware_interface</run_depend>
   <run_depend>joint_state_controller</run_depend>
   <run_depend>joint_trajectory_controller</run_depend>
+  <run_depend>brics_actuator</run_depend>
 
   <test_depend>roslaunch</test_depend>
   

--- a/youbot_gazebo_control/src/arm_joint_vel_convertor.cpp
+++ b/youbot_gazebo_control/src/arm_joint_vel_convertor.cpp
@@ -1,0 +1,108 @@
+/*
+ * This node converts commands from brics_actuator::JointVelocity type to
+ * individual joint's velocity command for simulated youbot arm.
+ */
+
+#include <ros/ros.h>
+#include <brics_actuator/JointVelocities.h>
+#include <std_msgs/Float64.h>
+
+std::vector<ros::Publisher> joint_pubs;
+ros::Subscriber joint_vel_sub;
+ros::Timer step_timer;
+size_t num_of_joints = 5;
+std::vector<float> joint_vel;
+std::vector<std::string> expected_joint_uri = {"arm_joint_1", "arm_joint_2", "arm_joint_3",
+                                      "arm_joint_4", "arm_joint_5"};
+std::string expected_unit = "s^-1 rad";
+
+void jointVelCb(const brics_actuator::JointVelocities::ConstPtr& msg)
+{
+    if ( msg->velocities.size() != num_of_joints )
+    {
+        ROS_ERROR_STREAM("Number of joints do not match. Expecting "
+                         << num_of_joints << ", got " << msg->velocities.size() << ".");
+        return;
+    }
+
+    for ( size_t i = 0; i < num_of_joints; i++ )
+    {
+        if ( msg->velocities[i].joint_uri != expected_joint_uri[i] )
+        {
+            ROS_ERROR_STREAM("joint_uri does not match. Expecting "
+                             << expected_joint_uri[i] << ", got "
+                             << msg->velocities[i].joint_uri << ".");
+            for ( size_t j = 0; j < num_of_joints; j++ )
+            {
+                joint_vel[j] = 0.0f;
+            }
+            return;
+        }
+
+        if ( msg->velocities[i].unit != expected_unit )
+        {
+            ROS_ERROR_STREAM("unit does not match. Expecting "
+                             << expected_unit << ", got "
+                             << msg->velocities[i].unit << ".");
+            for ( size_t j = 0; j < num_of_joints; j++ )
+            {
+                joint_vel[j] = 0.0f;
+            }
+            return;
+        }
+
+        joint_vel[i] = msg->velocities[i].value;
+    }
+};
+
+void step()
+{
+    for ( size_t i = 0; i < num_of_joints; i++ )
+    {
+        std_msgs::Float64 command_msg;
+        command_msg.data = joint_vel[i];
+        joint_pubs[i].publish(command_msg);
+    }
+};
+
+void init()
+{
+    ros::NodeHandle nh("~");
+    std::string arm_name;
+    nh.param<std::string>("arm_name", arm_name, "arm_1");
+    std::string arm_joint_vel_topic = "/" + arm_name + "/arm_controller/velocity_command";
+
+    joint_vel = std::vector<float>(5, 0.0f);
+
+    for ( size_t i = 0; i < num_of_joints; i++ )
+    {
+        std::stringstream joint_command_topic;
+        joint_command_topic << "/" << arm_name << "/joint_" << i+1 << "_velocity/command";
+        joint_pubs.push_back(nh.advertise<std_msgs::Float64>(joint_command_topic.str(), 1));
+    }
+
+    /* subscribers */
+    joint_vel_sub = nh.subscribe(arm_joint_vel_topic, 5, jointVelCb);
+
+};
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "arm_joint_vel_convertor");
+    init();
+    ros::NodeHandle nh("~");
+
+    /* ros params */
+    float loop_rate;
+    nh.param<float>("loop_rate", loop_rate, 10.0f);
+    ros::Rate rate(loop_rate);
+
+    while ( ros::ok() )
+    {
+        step();
+        ros::spinOnce();
+        rate.sleep();
+    }
+
+    return 0;
+}

--- a/youbot_gazebo_robot/launch/vel_youbot_arm.launch
+++ b/youbot_gazebo_robot/launch/vel_youbot_arm.launch
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<launch>
+
+  <!-- launch world -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="paused" value="false"/>
+    <arg name="use_sim_time" value="true"/>
+    <arg name="gui" value="true"/>
+    <arg name="headless" value="false"/>
+    <arg name="debug" value="false"/>
+    <arg name="world_name" value="worlds/empty.world"/>
+  </include>
+
+  <param name="robot_description" command="$(find xacro)/xacro.py $(find youbot_description)/robots/youbot_arm_only.urdf.xacro" />
+
+  <node pkg="gazebo_ros" type="spawn_model" name="spawn_robot" respawn="false" output="screen"
+    args="-param robot_description
+          -urdf
+          -x 0.0
+          -y 0.0
+          -z 0.0
+          -model youbot">
+  </node>
+
+  <!-- launch joint state controller -->
+  <include file="$(find youbot_gazebo_control)/launch/joint_state_controller.launch" />
+
+  <!-- launch arm controller -->
+  <include file="$(find youbot_gazebo_control)/launch/vel_arm_controller.launch" />
+  
+  <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
+    <param name="publish_frequency" type="double" value="30.0" />
+  </node>
+
+</launch>

--- a/youbot_gazebo_robot/launch/vel_youbot_arm.launch
+++ b/youbot_gazebo_robot/launch/vel_youbot_arm.launch
@@ -28,6 +28,9 @@
   <!-- launch arm controller -->
   <include file="$(find youbot_gazebo_control)/launch/vel_arm_controller.launch" />
   
+  <!-- launch gripper controller -->
+  <include file="$(find youbot_gazebo_control)/launch/gripper_controller.launch" />
+  
   <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
     <param name="publish_frequency" type="double" value="30.0" />
   </node>

--- a/youbot_gazebo_robot/launch/youbot.launch
+++ b/youbot_gazebo_robot/launch/youbot.launch
@@ -6,6 +6,7 @@
   <arg name="init_pos_x" default="0.0"/>
   <arg name="init_pos_y" default="0.0"/>
   <arg name="init_pos_z" default="0.1"/>
+  <arg name="use_traj_ctrl" default="true" />
 
   <!-- launch world -->
   <include file="$(find youbot_gazebo_worlds)/launch/$(arg world).launch" />
@@ -28,7 +29,12 @@
   <include file="$(find youbot_gazebo_control)/launch/base_controller.launch" />
 
   <!-- launch arm controller -->
-  <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  <group if="$(arg use_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  </group>
+  <group unless="$(arg use_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/vel_arm_controller.launch" />
+  </group>
   
   <!-- launch gripper controller -->
   <include file="$(find youbot_gazebo_control)/launch/gripper_controller.launch" />

--- a/youbot_gazebo_robot/launch/youbot_arm_only.launch
+++ b/youbot_gazebo_robot/launch/youbot_arm_only.launch
@@ -5,6 +5,7 @@
   <arg name="init_pos_x" default="1.7"/>
   <arg name="init_pos_y" default="0.0"/>
   <arg name="init_pos_z" default="0.2"/>
+  <arg name="use_traj_ctrl" default="true" />
 
   <!-- launch world -->
   <include file="$(find youbot_gazebo_worlds)/launch/$(arg world).launch" />
@@ -24,7 +25,12 @@
   <include file="$(find youbot_gazebo_control)/launch/joint_state_controller.launch" />
 
   <!-- launch arm controller -->
-  <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  <group if="$(arg use_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/arm_controller.launch" />
+  </group>
+  <group unless="$(arg use_traj_ctrl)">
+    <include file="$(find youbot_gazebo_control)/launch/vel_arm_controller.launch" />
+  </group>
   
   <!-- launch gripper controller -->
   <include file="$(find youbot_gazebo_control)/launch/gripper_controller.launch" />


### PR DESCRIPTION
Additional dependency:
- `ros-melodic-effort-controller`

To launch youbot arm with joint vel controller
```
roslaunch youbot_gazebo_robot youbot_arm_only.launch use_traj_ctrl:=false
```

To launch entire youbot
```
roslaunch youbot_gazebo_robot youbot.launch use_traj_ctrl:=false
```

Launching with velocity controller allows direct control on individual arm joint velocities with `brics_actuator/JointVelocities` whereas the default uses trajectory controller which is used by moveit. 

Unfortunately, both cannot be started at the same time since both controller would control the same joint and gazebo does not allow that.