### PR TITLE
xacro.py is deprecated; please use xacro instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,81 @@ youbot_simulation
 =================
 
 Packages to run the KUKA youBot in the Gazebo simulation with ROS
+
+
+
+#### Easy installation on ubuntu 20.04
+
+```bash
+cd ~/catkin_ws/src
+
+# check https://github.com/mas-group/youbot_simulation/pull/19
+# if it is accepted, then
+git clone https://github.com/mas-group/youbot_simulation.git --branch noetic-devel
+# else
+git clone https://github.com/d3dx13/youbot_simulation.git
+
+
+git clone https://github.com/mas-group/youbot_description.git
+
+cd ~/catkin_ws
+catkin build
+source ~/.bashrc
+
+```
+
+
+
+#### Start simulation in one terminal
+
+**OPTION 1:** Kuka manipulator only
+
+```bash
+killall rosmaster roscore gazebo roslaunch gzserver gzclient;
+rosrun gazebo_ros gazebo &
+roslaunch youbot_gazebo_robot youbot_arm_only.launch &
+
+```
+
+**OPTION 2:** Whole kuka youbot
+
+```bash
+killall rosmaster roscore gazebo roslaunch gzserver gzclient;
+rosrun gazebo_ros gazebo &
+roslaunch youbot_gazebo_robot youbot.launch &
+
+```
+
+
+
+#### Install some examples
+
+```bash
+cd ~/catkin_ws/src
+
+# required library
+git clone https://github.com/wnowak/brics_actuator.git
+
+# examples
+git clone https://github.com/d3dx13/youbot_ros_examples.git
+
+cd ~/catkin_ws
+catkin build
+source ~/.bashrc
+
+```
+
+
+
+#### Launch some examples
+
+Kuka manipulator moving
+
+`rosrun youbot_ros_simple_trajectory youbot_ros_simple_trajectory`
+
+YouBot platform moving (works only with **OPTION 2**)
+
+`rosrun youbot_ros_hello_world youbot_ros_hello_world`
+
+
+

--- a/youbot_gazebo_robot/launch/youbot.launch
+++ b/youbot_gazebo_robot/launch/youbot.launch
@@ -10,7 +10,7 @@
   <!-- launch world -->
   <include file="$(find youbot_gazebo_worlds)/launch/$(arg world).launch" />
 
-  <param name="robot_description" command="$(find xacro)/xacro.py $(find youbot_description)/robots/$(arg robot).urdf.xacro" />
+  <param name="robot_description" command="xacro $(find youbot_description)/robots/$(arg robot).urdf.xacro" />
 
   <node pkg="gazebo_ros" type="spawn_model" name="spawn_robot" respawn="false" output="screen"
     args="-param robot_description

--- a/youbot_gazebo_robot/launch/youbot_arm_only.launch
+++ b/youbot_gazebo_robot/launch/youbot_arm_only.launch
@@ -9,7 +9,7 @@
   <!-- launch world -->
   <include file="$(find youbot_gazebo_worlds)/launch/$(arg world).launch" />
 
-  <param name="robot_description" command="$(find xacro)/xacro.py $(find youbot_description)/robots/youbot_arm_only.urdf.xacro" />
+  <param name="robot_description" command="xacro $(find youbot_description)/robots/youbot_arm_only.urdf.xacro" />
 
   <node pkg="gazebo_ros" type="spawn_model" name="spawn_robot" respawn="false" output="screen"
     args="-param robot_description

--- a/youbot_gazebo_robot/launch/youbot_base_only.launch
+++ b/youbot_gazebo_robot/launch/youbot_base_only.launch
@@ -9,7 +9,7 @@
   <!-- launch world -->
   <include file="$(find youbot_gazebo_worlds)/launch/$(arg world).launch" />
 
-  <param name="robot_description" command="$(find xacro)/xacro.py $(find youbot_description)/robots/youbot_base_only.urdf.xacro" />
+  <param name="robot_description" command="xacro $(find youbot_description)/robots/youbot_base_only.urdf.xacro" />
 
   <node pkg="gazebo_ros" type="spawn_model" name="spawn_robot" respawn="false" output="screen"
     args="-param robot_description

--- a/youbot_gazebo_robot/launch/youbot_dual_arm.launch
+++ b/youbot_gazebo_robot/launch/youbot_dual_arm.launch
@@ -9,7 +9,7 @@
   <!-- launch world -->
   <include file="$(find youbot_gazebo_worlds)/launch/$(arg world).launch" />
 
-  <param name="robot_description" command="$(find xacro)/xacro.py $(find youbot_description)/robots/youbot_dual_arm.urdf.xacro" />
+  <param name="robot_description" command="xacro $(find youbot_description)/robots/youbot_dual_arm.urdf.xacro" />
 
   <node pkg="gazebo_ros" type="spawn_model" name="spawn_robot" respawn="false" output="screen"
     args="-param robot_description

--- a/youbot_gazebo_worlds/launch/robocup_at_work_2012.launch
+++ b/youbot_gazebo_worlds/launch/robocup_at_work_2012.launch
@@ -16,7 +16,7 @@
   </include>
 
     <!-- send world urdf to param server -->
-	<param name="world_description" command="$(find xacro)/xacro.py $(find youbot_gazebo_worlds)/urdf/robocup_at_work_2012.urdf" />
+	<param name="world_description" command="xacro $(find youbot_gazebo_worlds)/urdf/robocup_at_work_2012.urdf" />
 
     <!-- spawn uploaded world model -->
 	<node pkg="gazebo_ros" type="spawn_model" name="gazebo_world_model" args="-urdf -param world_description -model world -x 0.0 -y 0.0 -z 0.2" respawn="false" output="screen" />    

--- a/youbot_gazebo_worlds/launch/tower_of_hanoi.launch
+++ b/youbot_gazebo_worlds/launch/tower_of_hanoi.launch
@@ -16,7 +16,7 @@
   </include>
 
     <!-- send world urdf to param server -->
-	<param name="world_description" command="$(find xacro)/xacro.py $(find youbot_gazebo_worlds)/urdf/tower_of_hanoi.urdf" />
+	<param name="world_description" command="xacro $(find youbot_gazebo_worlds)/urdf/tower_of_hanoi.urdf" />
 
     <!-- spawn uploaded world model -->
 	<node pkg="gazebo_ros" type="spawn_model" name="gazebo_world_model" args="-urdf -param world_description -model world -x 1.0 -y 0.0 -z 0.2" respawn="false" output="screen" />    


### PR DESCRIPTION
In ros noetic on ubuntu 20.04 I could not run the simulation even when using the noetic-devel branch

This post at https://answers.ros.org fixed the problem

https://answers.ros.org/question/366957/problem-with-xacro-invalid-param/